### PR TITLE
Fix Left Hand Nav Menu Scaling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -105,7 +105,7 @@ main {
 }
 
 .last {
-  margin-top: 30rem;
+  margin-top: auto;
 }
 
 .nav-link {


### PR DESCRIPTION
Changes style.css line 107 from 30rem to auto, to allow for automatic scaling to always fit the user display when the navbar is displayed vertically on desktop sites.